### PR TITLE
[fix] JwtFilter Preflight 요청 허용

### DIFF
--- a/gateway/src/main/java/com/ticketPing/gateway/infrastructure/config/SecurityConfig.java
+++ b/gateway/src/main/java/com/ticketPing/gateway/infrastructure/config/SecurityConfig.java
@@ -24,8 +24,8 @@ public class SecurityConfig {
                 .csrf(ServerHttpSecurity.CsrfSpec::disable)
                 .formLogin(ServerHttpSecurity.FormLoginSpec::disable)
                 .httpBasic(ServerHttpSecurity.HttpBasicSpec::disable)
-                .securityContextRepository(jwtFilter)
                 .authorizeExchange(exchange -> exchange
+                        .pathMatchers(HttpMethod.OPTIONS).permitAll()
                         .pathMatchers("/api/v1/auth/login").permitAll()
                         .pathMatchers("/api/v1/auth/validate").permitAll()
                         .pathMatchers("/api/v1/auth/refresh").permitAll()
@@ -36,6 +36,8 @@ public class SecurityConfig {
                         .pathMatchers("/swagger-ui/**", "/v3/api-docs/**", "/webjars/**").permitAll()
                         .anyExchange().authenticated()
                 )
+                .securityContextRepository(jwtFilter)
                 .build();
     }
+
 }


### PR DESCRIPTION
## ✔️연관 이슈

> X

## 📝작업 내용

Preflight 요청의 헤더에서 jwt를 가져오지 못해 CORS 에러가 나는 문제 발생.
SecurityConfig에서 Option 요청을 허용하는 것으로 해결

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
