### PR TITLE
[fix #124] 좌석 선점 만료 이벤트 분산락 키 이름 수정

### DIFF
--- a/services/performance/src/main/java/com/ticketPing/performance/common/constants/SeatConstants.java
+++ b/services/performance/src/main/java/com/ticketPing/performance/common/constants/SeatConstants.java
@@ -9,7 +9,7 @@ public class SeatConstants {
     public static final String SEAT_CACHE_KEY = "seat";
     public static final String PRE_RESERVE_SEAT_KEY = "seat-ttl";
     public static final String CACHE_SCHEDULER_LOCK_KEY = "SchedulerLock";
-    public final static String PRE_RESERVE_EXPIRE_LOCK_KEY = "PreReserveLock:";
+    public static final String PRE_RESERVE_EXPIRE_LOCK_KEY = "PreReserveLock:";
 
 
     public static int PRE_RESERVE_TTL;

--- a/services/performance/src/main/java/com/ticketPing/performance/infrastructure/listener/RedisKeyExpiredListener.java
+++ b/services/performance/src/main/java/com/ticketPing/performance/infrastructure/listener/RedisKeyExpiredListener.java
@@ -30,7 +30,7 @@ public class RedisKeyExpiredListener implements MessageListener<String> {
 
             String scheduleId = expiredKey.split(":")[1].replaceAll("[{}]", "");
             String seatId = expiredKey.split(":")[2];
-            String lockKey = CACHE_SCHEDULER_LOCK_KEY + ":" + seatId;
+            String lockKey = PRE_RESERVE_EXPIRE_LOCK_KEY + ":" + seatId;
 
             try {
                 boolean executed = lockService.executeWithLock(lockKey, 0, LOCK_TIMEOUT, () -> {


### PR DESCRIPTION
## ✔️연관 이슈

- close #124 

## 📝작업 내용

> 좌석 선점 만료 이벤트 분산락 키 이름이 잘못되어 수정